### PR TITLE
Memory usage patch

### DIFF
--- a/src/MailToMbox.java
+++ b/src/MailToMbox.java
@@ -71,8 +71,17 @@ public class MailToMbox {
      *  object.
      */
     private void openCabinet(String pfcName) {
+        // Open PFC file for reading
+        RandomAccessFile pfcFile = null;
+        try {
+            pfcFile = new RandomAccessFile(pfcName, "r");
+        } catch (FileNotFoundException ex) {
+            System.err.println("Could not read cabinet file " + pfcName);
+            System.exit(1);
+        }
+
         // Create cabinet maker and start thread to read file.
-        CabinetMaker maker = new CabinetMaker(pfcName);
+        CabinetMaker maker = new CabinetMaker(pfcFile);
         Thread thread = new Thread(maker);
         thread.start();
         

--- a/src/pfc/cab/CabinetMaker.java
+++ b/src/pfc/cab/CabinetMaker.java
@@ -38,7 +38,7 @@ public class CabinetMaker implements Runnable {
     
     public static final String CABFILE_ID = "AOLVM100";
 
-    private String fileName;
+    RandomAccessFile pfcFile = null;
     private Cabinet cabinet;
     private int progressPct;
     private JProgressBar progressBar;
@@ -47,10 +47,10 @@ public class CabinetMaker implements Runnable {
 
     /**
      *  Constructor.
-     *  @param name cabinet file name
+     *  @param file cabinet file
      */
-    public CabinetMaker(String name) {
-        fileName = name;
+    public CabinetMaker(RandomAccessFile file) {
+        pfcFile = file;
         cabinet = null;
         progressPct = 0;
         progressBar = null;
@@ -102,15 +102,9 @@ public class CabinetMaker implements Runnable {
      *  Cabinet object.
      */
     public void run() {
-
-        RandomAccessFile pfcFile = null;
-
         try {
             // Create new Cabinet object.
             cabinet = new Cabinet();
-
-            // Open personal filing cabinet for read-only access
-            pfcFile = new RandomAccessFile(fileName, "r");
 
             // Read first 8 bytes; should = AOLVM100.
             pfcFile.seek(0);
@@ -206,13 +200,6 @@ public class CabinetMaker implements Runnable {
         }
         catch (CabinetException cex) {
             exception = cex;
-        }
-        finally {
-            // Close cabinet file.
-            if (pfcFile != null) {
-                try { pfcFile.close(); }
-                catch (IOException iox) { exception = iox; }
-            }
         }
 
         // Set progress bar to completion, and close dialog.

--- a/src/pfc/cab/CabinetMaker.java
+++ b/src/pfc/cab/CabinetMaker.java
@@ -147,23 +147,8 @@ public class CabinetMaker implements Runnable {
                 pfcFile.seek(i);
                 int cabAddr = IntUtil.reverseInt(pfcFile.readInt());
 
-                byte[] byteBuffer;
-                if (cabAddr != 0) {
-                    // Get item length.
-                    pfcFile.seek(cabAddr + 4);
-                    int length = IntUtil.reverseInt(pfcFile.readInt());
-
-                    // Read entire item into byte array.
-                    byteBuffer = new byte[length];
-                    pfcFile.read(byteBuffer);
-                }
-                else {
-                    // Create empty byte array for zero entry.
-                    byteBuffer = new byte[4];
-                }
-
                 // Create cabinet item.
-                CabinetItem item = new CabinetItem(byteBuffer);
+                CabinetItem item = new CabinetItem(pfcFile, cabAddr);
                 item.setIndex(itemCount++);
                 item.setAddress(cabAddr);
 

--- a/src/pfc/view/PfcViewFrame.java
+++ b/src/pfc/view/PfcViewFrame.java
@@ -304,6 +304,7 @@ public class PfcViewFrame extends javax.swing.JFrame {
     }
     
     // Custom variables
+    private RandomAccessFile pfcFile;
     private Cabinet cabinet;
     private CabinetTableModel tableModel;
     private File lastExportDir = new File(System.getProperty("user.dir"));
@@ -394,12 +395,22 @@ public class PfcViewFrame extends javax.swing.JFrame {
          */
         public void openCabinetFile(String filename) {
             jTextStatus.setText("Reading cabinet file " + filename);
-        
+
+            // Open the cabinet file in read-only mode
+            try {
+                pfcFile = new RandomAccessFile(filename, "r");
+            } catch (FileNotFoundException ex) {
+                jOptionPane1.showMessageDialog(PfcViewFrame.this, ex.toString(),
+                        "Open Cabinet", JOptionPane.ERROR_MESSAGE);
+                jTextStatus.setText("Could not read cabinet file " + filename);
+                return;
+            }
+
             // Create progress dialog.
             ProgressDialog dialog = new ProgressDialog(PfcViewFrame.this, true);
         
             // Create CabinetMaker and start thread to read cabinet file.
-            CabinetMaker maker = new CabinetMaker(filename);
+            CabinetMaker maker = new CabinetMaker(pfcFile);
             maker.setProgressBar(dialog.getProgressBar());
             maker.setProgressDialog(dialog);
             Thread thread = new Thread(maker);
@@ -457,6 +468,12 @@ public class PfcViewFrame extends javax.swing.JFrame {
             cabinet = null;
             jTreeFolders.setModel(null);
             tableModel.setCabinet(null);
+            // Close cabinet file.
+            if (pfcFile != null) {
+                try {
+                    pfcFile.close();
+                } catch (IOException iox) {}
+            }
             enableMenuItems();
         }
     }


### PR DESCRIPTION
Hi Ernie,

As we discussed earlier, I have a patch that avoids loading every PFC item into memory and leaves the file open so that they can be fetched from disk on an as-needed basis.

Please review the changes in the 'memory' branch I made and let me know if you have any comments.  I've tested my big PFC file and memory usage stays at around ~110MB (as opposed to ~900MB before this change).  I've also done a before-and-after comparison of exporting the data to an mbox file and there were no differences.

I think the only issue may be when there's another process mangling the PFC file while PFCViewer has it open.  This may result in some inconsistency if the file offsets get screwed up.

Hope this helps.  I'd appreciate any feedback you have.

-Zhan
